### PR TITLE
Remove lombok usages from ssolite for readability.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ allprojects {
     dependencyManagement {
         imports {
             mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
-	}
+        }
 
         dependencies {
-            dependency 'org.projectlombok:lombok:1.16.20'
+            dependency 'org.projectlombok:lombok:1.18.10'
 
             dependency 'javax.servlet:javax.servlet-api:3.1.0'
             dependency 'javax.validation:validation-api:2.0.0.Final'
@@ -58,68 +58,10 @@ subprojects { subproject ->
                                      '-parameters']
         }
 
-        task delombok(type: JavaExec, dependsOn: compileJava) {
-            ext.outputDir = file("${buildDir}/delombok")
-            outputs.dir outputDir
-
-            classpath configurations.compile, configurations.compileOnly
-            main = 'lombok.launch.Main'
-            args 'delombok'
-            sourceSets.main.java.srcDirs.each {
-                inputs.dir it
-                args it, '-d', outputDir
-            }
-        }
-
         tasks.withType(Javadoc) {
-            dependsOn delombok
-            source = delombok.outputDir
-
             options.encoding = encoding
             options.charSet = encoding
-            //options.links 'http://docs.oracle.com/javase/8/docs/api/'
-        }
-    }
-
-    plugins.withId('eclipse') {
-        eclipse {
-            project {
-                name = path.substring(1).replaceAll(':', '-')
-                natures 'org.eclipse.buildship.core.gradleprojectnature'
-                buildCommand 'org.eclipse.buildship.core.gradleprojectbuilder'
-            }
-
-            classpath {
-                downloadSources = true
-                downloadJavadoc = true
-
-                file {
-                    whenMerged { classpath ->
-                        classpath.entries.findAll { it.kind == 'lib' }*.exported = true
-                    }
-                }
-            }
-        }
-
-        tasks.eclipse {
-            dependsOn cleanEclipse
-            doLast {
-                def settings_dir = file('.settings')
-                if (settings_dir.exists()) {
-                    def project_dir = (['..'] * project.depth).join('/')
-                    file("${settings_dir}/org.eclipse.buildship.core.prefs").append("""
-                        connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
-                        connection.project.dir=${project_dir}
-                        eclipse.preferences.version=1
-                    """.stripIndent())
-                }
-            }
-        }
-
-        tasks.cleanEclipse {
-            doLast {
-                delete '.settings'
-            }
+            // options.links 'http://docs.oracle.com/javase/8/docs/api/'
         }
 
         tasks.clean {
@@ -128,22 +70,39 @@ subprojects { subproject ->
             }
         }
     }
+
+    plugins.withId('eclipse') {
+        eclipse {
+            project {
+                name = path.substring(1).replaceAll(':', '-')
+            }
+
+            classpath {
+                downloadSources = true
+                downloadJavadoc = true
+            }
+        }
+
+        tasks.cleanEclipse.doLast {
+            delete '.settings'
+        }
+    }
 }
 
 // ===================================================================
 //  ssolite
 // ===================================================================
-project(':ssolite') {
+def mainProjects = subprojects.findAll { it.path.startsWith(':ssolite') }
+
+configure(mainProjects) {
     group = 'com.github.sahara3'
-    version = '0.0.5'
+    version = '1.0.0-SNAPSHOT'
 
     apply plugin: 'java'
-    apply plugin: 'maven'
     apply plugin: 'eclipse'
 
     dependencies {
         compileOnly 'javax.servlet:javax.servlet-api'
-        compile 'javax.validation:validation-api'
         compile 'org.springframework:spring-web'
         compile 'org.springframework.security:spring-security-web'
         compile 'org.springframework.security:spring-security-config'
@@ -162,6 +121,8 @@ project(':ssolite') {
     // ---------------------------------------------------------------
     // Maven Publising
     // ---------------------------------------------------------------
+    apply plugin: 'maven'
+
     configurations {
         deployerJars
     }
@@ -180,7 +141,7 @@ project(':ssolite') {
         }
     }
 
-    task sourcesJar(type: Jar, dependsOn:classes) {
+    task sourceJar(type: Jar, dependsOn:classes) {
         classifier = 'sources'
         from sourceSets.main.allSource
     }
@@ -191,7 +152,7 @@ project(':ssolite') {
     }
 
     artifacts {
-        archives sourcesJar
+        archives sourceJar
         archives javadocJar
     }
 }
@@ -199,14 +160,43 @@ project(':ssolite') {
 // ===================================================================
 //  Sample Server and Client
 // ===================================================================
-project(':sample-server') {
+def sampleProjects = subprojects.findAll { it.path.startsWith(':sample') }
+
+configure(sampleProjects) {
     apply plugin: 'java'
     apply plugin: 'eclipse'
+
+    dependencies {
+        compileOnly 'org.projectlombok:lombok'
+        testCompileOnly 'org.projectlombok:lombok'
+
+        compile 'javax.validation:validation-api'
+        compile project(':ssolite')
+    }
+
+    task delombok(type: JavaExec, dependsOn: compileJava) {
+        ext.outputDir = file("${buildDir}/delombok")
+        outputs.dir outputDir
+
+        classpath configurations.compile, configurations.compileOnly
+        main = 'lombok.launch.Main'
+        args 'delombok'
+        sourceSets.main.java.srcDirs.each {
+            inputs.dir it
+            args it, '-d', outputDir
+        }
+    }
+
+    tasks.withType(Javadoc) {
+        dependsOn delombok
+        source = delombok.outputDir
+    }
+}
+
+project(':sample-server') {
     apply plugin: 'org.springframework.boot'
 
     dependencies {
-        compile project(':ssolite')
-        compile 'javax.validation:validation-api'
         compile 'org.springframework.boot:spring-boot-starter-web'
         compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
         compile 'org.springframework.boot:spring-boot-starter-security'
@@ -217,13 +207,9 @@ project(':sample-server') {
 }
 
 project(':sample-client-spring') {
-    apply plugin: 'java'
-    apply plugin: 'eclipse'
     apply plugin: 'org.springframework.boot'
 
     dependencies {
-        compile project(':ssolite')
-        compile 'javax.validation:validation-api'
         compile 'org.springframework.boot:spring-boot-starter-web'
         compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
         compile 'org.springframework.boot:spring-boot-starter-security'
@@ -233,16 +219,12 @@ project(':sample-client-spring') {
 }
 
 project(':sample-client-struts2') {
-    apply plugin: 'java'
     apply plugin: 'war'
-    apply plugin: 'eclipse'
     apply plugin: 'org.akhikhl.gretty'
 
     dependencies {
         compileOnly 'javax.servlet:javax.servlet-api'
 
-        compile project(':ssolite')
-        compile 'javax.validation:validation-api'
         compile 'org.apache.struts:struts2-core'
         compile 'com.squareup.okhttp3:okhttp'
         compile 'com.fasterxml.jackson.core:jackson-databind'

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/client/ExternalAuthenticationEntryPoint.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/client/ExternalAuthenticationEntryPoint.java
@@ -6,18 +6,17 @@ import java.nio.charset.StandardCharsets;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
+import org.springframework.util.Assert;
 import org.springframework.web.util.UriUtils;
 
 import com.github.sahara3.ssolite.util.SsoLiteRedirectUrlBuilder;
-
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * {@link AuthenticationEntryPoint} implementation that redirects to an external
@@ -25,10 +24,10 @@ import lombok.extern.slf4j.Slf4j;
  *
  * @author sahara3
  */
-@Slf4j
 public class ExternalAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-	@NotNull
+	private static final Logger LOG = LoggerFactory.getLogger(ExternalAuthenticationEntryPoint.class);
+
 	private final String loginFormUrl;
 
 	private final boolean sameDomain;
@@ -43,7 +42,8 @@ public class ExternalAuthenticationEntryPoint implements AuthenticationEntryPoin
 	 * @param sameDomain
 	 *            set true if the {@code loginFormUrl} is on the same domain.
 	 */
-	public ExternalAuthenticationEntryPoint(@NonNull String loginFormUrl, boolean sameDomain) {
+	public ExternalAuthenticationEntryPoint(String loginFormUrl, boolean sameDomain) {
+		Assert.notNull(loginFormUrl, "loginFormUrl cannot be null");
 		this.loginFormUrl = loginFormUrl;
 		this.sameDomain = sameDomain;
 	}
@@ -59,7 +59,7 @@ public class ExternalAuthenticationEntryPoint implements AuthenticationEntryPoin
 	 * @param loginFormUrl
 	 *            the URL of login form.
 	 */
-	public ExternalAuthenticationEntryPoint(@NonNull String loginFormUrl) {
+	public ExternalAuthenticationEntryPoint(String loginFormUrl) {
 		this(loginFormUrl, false);
 	}
 
@@ -68,12 +68,14 @@ public class ExternalAuthenticationEntryPoint implements AuthenticationEntryPoin
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 			AuthenticationException authException) throws IOException, ServletException {
-
 		String url = this.buildRedirectUrl(request, this.loginFormUrl);
 		this.redirectStrategy.sendRedirect(request, response, url);
 	}
 
-	private String buildRedirectUrl(@NonNull HttpServletRequest request, @NonNull String url) {
+	private String buildRedirectUrl(HttpServletRequest request, String url) {
+		Assert.notNull(request, "request cannot be null");
+		Assert.notNull(url, "url cannot be null");
+
 		String from = this.generateFromUrl(request);
 		LOG.debug("buildRedirectUrl: url={}, from={}", url, from);
 
@@ -89,7 +91,9 @@ public class ExternalAuthenticationEntryPoint implements AuthenticationEntryPoin
 		return redirectUrl;
 	}
 
-	private String generateFromUrl(@NonNull HttpServletRequest request) {
+	private String generateFromUrl(HttpServletRequest request) {
+		Assert.notNull(request, "request cannot be null");
+
 		if (this.sameDomain) {
 			String from = request.getRequestURI();
 			String query = request.getQueryString();

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/client/SsoLiteAccessTokenAuthenticationProcessingFilter.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/client/SsoLiteAccessTokenAuthenticationProcessingFilter.java
@@ -7,8 +7,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 
-import lombok.NonNull;
-
 /**
  * Authentication processing filter for SSOLite client.
  *
@@ -20,7 +18,7 @@ public class SsoLiteAccessTokenAuthenticationProcessingFilter extends AbstractAu
 	 * @param filterProcessesUrl
 	 *            the default filter processing URL.
 	 */
-	public SsoLiteAccessTokenAuthenticationProcessingFilter(@NonNull String filterProcessesUrl) {
+	public SsoLiteAccessTokenAuthenticationProcessingFilter(String filterProcessesUrl) {
 		super(filterProcessesUrl);
 	}
 

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/client/SsoLiteAccessTokenAuthenticationProvider.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/client/SsoLiteAccessTokenAuthenticationProvider.java
@@ -1,5 +1,7 @@
 package com.github.sahara3.ssolite.client;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -19,34 +21,38 @@ import org.springframework.web.client.RestTemplate;
 
 import com.github.sahara3.ssolite.model.SsoLiteAccessToken;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * Authentication provider for SSOLite client.
  *
  * @author sahara3
  *
  */
-@Slf4j
 public class SsoLiteAccessTokenAuthenticationProvider implements AuthenticationProvider {
+
+	private static final Logger LOG = LoggerFactory.getLogger(SsoLiteAccessTokenAuthenticationProvider.class);
 
 	@Override
 	public boolean supports(Class<?> authentication) {
 		return SsoLiteAccessTokenAuthenticationToken.class.isAssignableFrom(authentication);
 	}
 
-	@Getter
 	private final String accessTokenApiUrl;
 
-	@Getter(AccessLevel.PROTECTED)
+	public String getAccessTokenApiUrl() {
+		return this.accessTokenApiUrl;
+	}
+
 	private final RestTemplate restTemplate;
 
-	@Getter(AccessLevel.PROTECTED)
+	protected RestTemplate getRestTemplate() {
+		return this.restTemplate;
+	}
+
 	private final UserDetailsService userDetailsService;
+
+	protected UserDetailsService getUserDetailsService() {
+		return this.userDetailsService;
+	}
 
 	/**
 	 * @param accessTokenApiUrl
@@ -56,20 +62,37 @@ public class SsoLiteAccessTokenAuthenticationProvider implements AuthenticationP
 	 * @param userDetailsService
 	 *            Your {@link UserDetailsService} implementation.
 	 */
-	public SsoLiteAccessTokenAuthenticationProvider(@NonNull String accessTokenApiUrl,
-			@NonNull RestTemplate restTemplate, @NonNull UserDetailsService userDetailsService) {
+	public SsoLiteAccessTokenAuthenticationProvider(String accessTokenApiUrl, RestTemplate restTemplate,
+			UserDetailsService userDetailsService) {
+		Assert.notNull(accessTokenApiUrl, "accessTokenApiUrl cannot be null");
+		Assert.notNull(restTemplate, "restTemplate cannot be null");
+		Assert.notNull(userDetailsService, "userDetailsService cannot be null");
+
 		this.accessTokenApiUrl = accessTokenApiUrl;
 		this.restTemplate = restTemplate;
 		this.userDetailsService = userDetailsService;
 	}
 
-	@Getter(AccessLevel.PROTECTED)
-	@Setter
 	private UserDetailsChecker authenticationChecks = new DefaultAuthenticationChecks();
 
-	@Getter(AccessLevel.PROTECTED)
-	@Setter
+	protected UserDetailsChecker getAuthenticationChecks() {
+		return this.authenticationChecks;
+	}
+
+	public void setAuthenticationChecks(UserDetailsChecker authenticationChecks) {
+		Assert.notNull(authenticationChecks, "authenticationChecks cannot be null");
+		this.authenticationChecks = authenticationChecks;
+	}
+
 	private boolean hideUserNotFoundExceptions = false;
+
+	protected boolean isHideUserNotFoundExceptions() {
+		return this.hideUserNotFoundExceptions;
+	}
+
+	public void setHideUserNotFoundExceptions(boolean hideUserNotFoundExceptions) {
+		this.hideUserNotFoundExceptions = hideUserNotFoundExceptions;
+	}
 
 	@Override
 	public Authentication authenticate(Authentication authentication) throws AuthenticationException {

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/client/SsoLiteClientLoginConfigurer.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/client/SsoLiteClientLoginConfigurer.java
@@ -1,7 +1,5 @@
 package com.github.sahara3.ssolite.client;
 
-import javax.validation.constraints.NotNull;
-
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,8 +10,7 @@ import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
-
-import lombok.NonNull;
+import org.springframework.util.Assert;
 
 /**
  * Configures SSOLite client authentication.
@@ -22,18 +19,16 @@ import lombok.NonNull;
  */
 public class SsoLiteClientLoginConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
-	@NotNull
 	private final SsoLiteAccessTokenAuthenticationProcessingFilter authenticationFilter;
 
 	/**
 	 * Creates a new SSOLIte client authentication configurator.
 	 *
 	 * @param filterProcessesUrl
-	 *            the URL where a
-	 *            {@link SsoLiteAccessTokenAuthenticationProcessingFilter}
-	 *            works.
+	 *            the URL where a {@link SsoLiteAccessTokenAuthenticationProcessingFilter} works.
 	 */
-	public SsoLiteClientLoginConfigurer(@NonNull String filterProcessesUrl) {
+	public SsoLiteClientLoginConfigurer(String filterProcessesUrl) {
+		Assert.notNull(filterProcessesUrl, "filterProcessesUrl cannot be null");
 		this.authenticationFilter = new SsoLiteAccessTokenAuthenticationProcessingFilter(filterProcessesUrl);
 		this.successHandler = new SsoLiteClientAuthenticationSuccessHandler();
 		this.failureHandler = new SimpleUrlAuthenticationFailureHandler();

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/client/package-info.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/client/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package com.github.sahara3.ssolite.client;

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/config/SsoLiteClientProperties.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/config/SsoLiteClientProperties.java
@@ -1,8 +1,8 @@
 package com.github.sahara3.ssolite.config;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import java.util.Objects;
 
-import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Client properties of SSOLite.
@@ -10,21 +10,90 @@ import lombok.Data;
  * @author sahara3
  */
 @ConfigurationProperties(prefix = "ssolite.client")
-@Data
 public class SsoLiteClientProperties {
 
-	/**
-	 * Server URL of SSO login page.
-	 */
 	private String loginUrl = "/login";
 
 	/**
-	 * Server URL of SSO token RESTful API.
+	 * Server URL of SSO login page.
+	 *
+	 * @return the login page URL
 	 */
+	public String getLoginUrl() {
+		return this.loginUrl;
+	}
+
+	/**
+	 * @param loginUrl the login page URL to set
+	 */
+	public void setLoginUrl(String loginUrl) {
+		this.loginUrl = loginUrl;
+	}
+
 	private String tokenApiUrl = "/api/tokens";
 
 	/**
-	 * True if the server and client are at the same domain.
+	 * Server URL of SSO token RESTful API.
+	 *
+	 * @return the token API URL
+	 */
+	public String getTokenApiUrl() {
+		return this.tokenApiUrl;
+	}
+
+	/**
+	 * @param tokenApiUrl
+	 *            the token API URL to set
+	 */
+	public void setTokenApiUrl(String tokenApiUrl) {
+		this.tokenApiUrl = tokenApiUrl;
+	}
+
+	/**
 	 */
 	private boolean sameDomain = false;
+
+	/**
+	 * True if the server and client are at the same domain.
+	 *
+	 * @return the same domain flag
+	 */
+	public boolean isSameDomain() {
+		return this.sameDomain;
+	}
+
+	/**
+	 * @param sameDomain
+	 *            the same domain flag to set
+	 */
+	public void setSameDomain(boolean sameDomain) {
+		this.sameDomain = sameDomain;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.loginUrl, this.tokenApiUrl, this.sameDomain);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (this.getClass() != obj.getClass()) {
+			return false;
+		}
+		SsoLiteClientProperties other = (SsoLiteClientProperties) obj;
+		return Objects.equals(this.loginUrl, other.loginUrl) && Objects.equals(this.tokenApiUrl, other.tokenApiUrl)
+				&& this.sameDomain == other.sameDomain;
+	}
+
+	@Override
+	public String toString() {
+		return "SsoLiteClientProperties(loginUrl=" + this.loginUrl + ", sameDomain=" + this.sameDomain
+				+ ", tokenApiUrl=" + this.tokenApiUrl + ")";
+	}
 }

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/config/SsoLiteServerAutoConfiguration.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/config/SsoLiteServerAutoConfiguration.java
@@ -7,14 +7,13 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.util.Assert;
 
 import com.github.sahara3.ssolite.server.repository.SsoLiteAccessTokenRepository;
 import com.github.sahara3.ssolite.server.repository.SsoLiteAccessTokenRepositoryImpl;
 import com.github.sahara3.ssolite.server.service.SsoLiteAccessTokenService;
 import com.github.sahara3.ssolite.server.service.SsoLiteAccessTokenServiceImpl;
 import com.github.sahara3.ssolite.server.service.SsoLiteServerRedirectResolver;
-
-import lombok.NonNull;
 
 /**
  * Server auto configuration for SSOLite.
@@ -25,6 +24,7 @@ import lombok.NonNull;
 @ConditionalOnClass(EnableWebSecurity.class)
 @ConditionalOnProperty(prefix = "ssolite.server", name = "enabled", havingValue = "true", matchIfMissing = false)
 @EnableConfigurationProperties(SsoLiteServerProperties.class)
+@SuppressWarnings("static-method")
 public class SsoLiteServerAutoConfiguration {
 
 	/**
@@ -34,7 +34,6 @@ public class SsoLiteServerAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean(SsoLiteAccessTokenRepository.class)
-	@SuppressWarnings("static-method")
 	public SsoLiteAccessTokenRepository ssoAccessTokenRepository() {
 		return new SsoLiteAccessTokenRepositoryImpl();
 	}
@@ -48,9 +47,9 @@ public class SsoLiteServerAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean(SsoLiteAccessTokenService.class)
-	@SuppressWarnings("static-method")
 	public SsoLiteAccessTokenService ssoAccessTokenService(
-			@NonNull SsoLiteAccessTokenRepository ssoLiteAccessTokenRepository) {
+			SsoLiteAccessTokenRepository ssoLiteAccessTokenRepository) {
+		Assert.notNull(ssoLiteAccessTokenRepository, "ssoLiteAccessTokenRepository cannot be null");
 		return new SsoLiteAccessTokenServiceImpl(ssoLiteAccessTokenRepository);
 	}
 
@@ -65,10 +64,11 @@ public class SsoLiteServerAutoConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean(SsoLiteServerRedirectResolver.class)
-	@SuppressWarnings("static-method")
 	public SsoLiteServerRedirectResolver ssoLiteServerRedirectResolver(
-			@NonNull SsoLiteAccessTokenService ssoLiteAccessTokenService,
-			@NonNull SsoLiteServerProperties ssoLiteServerProperties) {
+			SsoLiteAccessTokenService ssoLiteAccessTokenService,
+			SsoLiteServerProperties ssoLiteServerProperties) {
+		Assert.notNull(ssoLiteAccessTokenService, "ssoLiteAccessTokenService cannot be null");
+		Assert.notNull(ssoLiteServerProperties, "ssoLiteServerProperties cannot be null");
 		SsoLiteServerRedirectResolver resolver = new SsoLiteServerRedirectResolver(ssoLiteAccessTokenService);
 		resolver.setPermittedDomainMap(ssoLiteServerProperties.getPermittedDomainMap());
 		return resolver;

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/config/SsoLiteServerProperties.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/config/SsoLiteServerProperties.java
@@ -6,8 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import javax.annotation.PostConstruct;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,47 +14,81 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import com.github.sahara3.ssolite.util.SsoLiteUriUtils;
 
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Setter;
-
 /**
  * Server properties of SSOLite.
  *
  * @author sahara3
  */
 @ConfigurationProperties(prefix = "ssolite.server")
-@Data
 public class SsoLiteServerProperties {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SsoLiteServerProperties.class);
 
+	private String defaultTopPageUrl = "internal:/";
+
 	/**
 	 * Default top page URL after login.
 	 *
+	 * <p>
 	 * If a URL starts with &quot;internal:&quot;, a path is relative from the
 	 * context root.
+	 * </p>
+	 *
+	 * @return the default top page URL
 	 */
-	private String defaultTopPageUrl = "internal:/";
+	public String getDefaultTopPageUrl() {
+		return this.defaultTopPageUrl;
+	}
+
+	/**
+	 * @param defaultTopPageUrl
+	 *            the default top page URL to set
+	 */
+	public void setDefaultTopPageUrl(String defaultTopPageUrl) {
+		this.defaultTopPageUrl = defaultTopPageUrl;
+	}
+
+	private List<String> permittedDomains = new ArrayList<>();
 
 	/**
 	 * List of the SSO permitted domain URLs.
 	 *
+	 * <p>
 	 * Each URL points the SSO login processing path in the client.
+	 * </p>
+	 *
+	 * @return the list of the permitted domain URLs
 	 */
-	private List<String> permittedDomains = new ArrayList<>();
+	public List<String> getPermittedDomains() {
+		return this.permittedDomains;
+	}
+
+	/**
+	 * @param permittedDomains
+	 *            the permitted domain URLs to set
+	 */
+	public void setPermittedDomains(List<String> permittedDomains) {
+		this.permittedDomains = permittedDomains;
+		this.updatePermittedDomainMap();
+	}
+
+	private Map<URI, URI> permittedDomainMap;
 
 	/**
 	 * Map of SSO permitted domains.
 	 *
+	 * <p>
 	 * Key is a domain only URL, and value is a URL pointed at the SSO login
 	 * processing path in a client.
+	 * </p>
+	 *
+	 * @return the permitted domain map
 	 */
-	@Setter(AccessLevel.NONE)
-	private Map<URI, URI> permittedDomainMap;
+	public Map<URI, URI> getPermittedDomainMap() {
+		return this.permittedDomainMap;
+	}
 
-	@PostConstruct
-	protected void init() {
+	private void updatePermittedDomainMap() {
 		this.permittedDomainMap = new HashMap<>();
 
 		this.permittedDomains.forEach(s -> {
@@ -64,10 +97,36 @@ public class SsoLiteServerProperties {
 				URI domainUri = SsoLiteUriUtils.getDomainUri(ssoLoginUri);
 				this.permittedDomainMap.put(domainUri, ssoLoginUri);
 				LOG.debug("Permitted domain: {}", s);
-			}
-			catch (URISyntaxException e) {
+			} catch (URISyntaxException e) {
 				LOG.warn("Invalid URI: " + s, e);
 			}
 		});
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.defaultTopPageUrl, this.permittedDomains);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (this.getClass() != obj.getClass()) {
+			return false;
+		}
+		SsoLiteServerProperties other = (SsoLiteServerProperties) obj;
+		return Objects.equals(this.defaultTopPageUrl, other.defaultTopPageUrl)
+				&& Objects.equals(this.permittedDomains, other.permittedDomains);
+	}
+
+	@Override
+	public String toString() {
+		return "SsoLiteServerProperties(defaultTopPageUrl=" + this.defaultTopPageUrl + ", permittedDomains="
+				+ this.permittedDomains + ")";
 	}
 }

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/config/package-info.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/config/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package com.github.sahara3.ssolite.config;

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/model/SsoLiteAccessToken.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/model/SsoLiteAccessToken.java
@@ -1,24 +1,78 @@
 package com.github.sahara3.ssolite.model;
 
 import java.util.Date;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * SSOLite access token entity.
  *
  * @author sahara3
  */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class SsoLiteAccessToken {
+
+	public SsoLiteAccessToken() {
+		// do nothing.
+	}
+
+	public SsoLiteAccessToken(String id, String username, Date expired) {
+		this.id = id;
+		this.username = username;
+		this.expired = expired;
+	}
 
 	private String id;
 
+	public String getId() {
+		return this.id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
 	private String username;
 
+	public String getUsername() {
+		return this.username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
 	private Date expired;
+
+	public Date getExpired() {
+		return this.expired;
+	}
+
+	public void setExpired(Date expired) {
+		this.expired = expired;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.id, this.username, this.expired);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (this.getClass() != obj.getClass()) {
+			return false;
+		}
+		SsoLiteAccessToken other = (SsoLiteAccessToken) obj;
+		return Objects.equals(this.id, other.id) && Objects.equals(this.username, other.username) &&
+				Objects.equals(this.expired, other.expired);
+	}
+
+	@Override
+	public String toString() {
+		return "SsoLiteAccessToken(id=" + this.id + ", username=" + this.username + ", expired=" + this.expired + ")";
+	}
 }

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/SsoLiteServerAuthenticationFailureHandler.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/SsoLiteServerAuthenticationFailureHandler.java
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -19,27 +18,24 @@ import org.springframework.security.web.util.UrlUtils;
 import org.springframework.util.Assert;
 import org.springframework.web.util.UriUtils;
 
-import lombok.NonNull;
-
 /**
  * Authentication failure handler for SSOLite server.
  *
  * @author sahara3
  */
 public class SsoLiteServerAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
-	@NotNull
 	private final String forwardUrl;
 
-	@NotNull
 	private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 
 	/**
 	 * @param forwardUrl
 	 *            URL to forward when login failure.
 	 */
-	public SsoLiteServerAuthenticationFailureHandler(@NonNull String forwardUrl) {
+	public SsoLiteServerAuthenticationFailureHandler(String forwardUrl) {
 		Assert.isTrue(UrlUtils.isValidRedirectUrl(forwardUrl), "'" + forwardUrl + "' is not a valid forward URL");
 		this.forwardUrl = forwardUrl;
 	}

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/SsoLiteServerAuthenticationSuccessHandler.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/SsoLiteServerAuthenticationSuccessHandler.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
@@ -18,31 +17,47 @@ import org.springframework.util.StringUtils;
 import com.github.sahara3.ssolite.server.service.SsoLiteServerRedirectResolver;
 import com.github.sahara3.ssolite.util.SsoLiteRedirectUrlBuilder;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-
 /**
  * Authentication success handler for SSOLite server.
  *
  * @author sahara3
  */
-@RequiredArgsConstructor
 public class SsoLiteServerAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
-	@NotNull
 	protected final SsoLiteServerRedirectResolver redirectResolver;
 
-	@NotNull
-	@Getter
-	@Setter
+	public SsoLiteServerAuthenticationSuccessHandler(SsoLiteServerRedirectResolver redirectResolver) {
+		this.redirectResolver = redirectResolver;
+	}
+
 	protected String defaultTopPageUrl;
 
-	@NotNull
-	@Setter
+	/**
+	 * @return the default top page URL
+	 */
+	public String getDefaultTopPageUrl() {
+		return defaultTopPageUrl;
+	}
+
+	/**
+	 * @param defaultTopPageUrl
+	 *            the default top page URL to set
+	 */
+	public void setDefaultTopPageUrl(String defaultTopPageUrl) {
+		Assert.notNull(defaultTopPageUrl, "defaultTopPageUrl cannot be null");
+		this.defaultTopPageUrl = defaultTopPageUrl;
+	}
+
 	protected Map<URI, URI> permittedDomainMap = new HashMap<>();
+
+	/**
+	 * @param permittedDomainMap
+	 *            the permitted domain map to set
+	 */
+	public void setPermittedDomainMap(Map<URI, URI> permittedDomainMap) {
+		Assert.notNull(permittedDomainMap, "permittedDomainMap cannot be null");
+		this.permittedDomainMap = permittedDomainMap;
+	}
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -68,7 +83,6 @@ public class SsoLiteServerAuthenticationSuccessHandler extends SavedRequestAware
 			// internal redirection.
 			super.onAuthenticationSuccess(request, response, authentication);
 		}
-		return;
 	}
 
 	// ========================================================================
@@ -77,8 +91,11 @@ public class SsoLiteServerAuthenticationSuccessHandler extends SavedRequestAware
 
 	private final SsoLiteRedirectUrlBuilder redirectUrlBuilder = new SsoLiteRedirectUrlBuilder();
 
-	@Getter(AccessLevel.PROTECTED)
 	private boolean useReferer = false;
+
+	protected boolean isUseReferer() {
+		return this.useReferer;
+	}
 
 	@Override
 	public void setUseReferer(boolean useReferer) {
@@ -87,7 +104,7 @@ public class SsoLiteServerAuthenticationSuccessHandler extends SavedRequestAware
 	}
 
 	@Override
-	protected String determineTargetUrl(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response) {
+	protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
 		if (this.isAlwaysUseDefaultTargetUrl()) {
 			return this.determineDefaultTargetUrl(request);
 		}
@@ -118,7 +135,9 @@ public class SsoLiteServerAuthenticationSuccessHandler extends SavedRequestAware
 		return target;
 	}
 
-	protected String determineDefaultTargetUrl(@NonNull HttpServletRequest request) {
+	protected String determineDefaultTargetUrl(HttpServletRequest request) {
+		Assert.notNull(request, "request cannot be null");
+
 		String top = this.getDefaultTopPageUrl();
 		return this.redirectUrlBuilder.buildRedirectUrl(request, top);
 	}

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/package-info.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package com.github.sahara3.ssolite.server;

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/repository/SsoLiteAccessTokenRepository.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/repository/SsoLiteAccessTokenRepository.java
@@ -1,8 +1,8 @@
 package com.github.sahara3.ssolite.server.repository;
 
-import javax.validation.constraints.NotNull;
-
 import com.github.sahara3.ssolite.model.SsoLiteAccessToken;
+
+import org.springframework.lang.Nullable;
 
 /**
  * Repository interface of SSOLite access tokens.
@@ -18,7 +18,8 @@ public interface SsoLiteAccessTokenRepository {
 	 *            must not be null.
 	 * @return the access token with the given ID, or null if not found.
 	 */
-	SsoLiteAccessToken findById(@NotNull String id);
+	@Nullable
+	SsoLiteAccessToken findById(String id);
 
 	/**
 	 * Saves a given access token.
@@ -26,7 +27,7 @@ public interface SsoLiteAccessTokenRepository {
 	 * @param token
 	 *            must not be null.
 	 */
-	void save(@NotNull SsoLiteAccessToken token);
+	void save(SsoLiteAccessToken token);
 
 	/**
 	 * Deletes an access token by its ID.
@@ -34,6 +35,6 @@ public interface SsoLiteAccessTokenRepository {
 	 * @param id
 	 *            must not be null.
 	 */
-	void delete(@NotNull String id);
+	void delete(String id);
 
 }

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/repository/SsoLiteAccessTokenRepositoryImpl.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/repository/SsoLiteAccessTokenRepositoryImpl.java
@@ -4,9 +4,10 @@ import java.util.Date;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import javax.validation.constraints.NotNull;
-
 import com.github.sahara3.ssolite.model.SsoLiteAccessToken;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * In-memory implementation of {@link SsoLiteAccessTokenRepository} interface.
@@ -18,20 +19,24 @@ public class SsoLiteAccessTokenRepositoryImpl implements SsoLiteAccessTokenRepos
 	private final ConcurrentMap<String, SsoLiteAccessToken> tokens = new ConcurrentHashMap<>();
 
 	@Override
-	public SsoLiteAccessToken findById(@NotNull String id) {
+	@Nullable
+	public SsoLiteAccessToken findById(String id) {
+		Assert.notNull(id, "id cannot be null");
 		SsoLiteAccessToken token = this.tokens.get(id);
 		return token;
 	}
 
 	@Override
-	public void save(@NotNull SsoLiteAccessToken token) {
+	public void save(SsoLiteAccessToken token) {
+		Assert.notNull(token, "token cannot be null");
 		this.tokens.put(token.getId(), token);
 
 		this.cleanupExpiredTokens();
 	}
 
 	@Override
-	public void delete(@NotNull String id) {
+	public void delete(String id) {
+		Assert.notNull(id, "id cannot be null");
 		this.tokens.remove(id);
 
 		this.cleanupExpiredTokens();

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/repository/package-info.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/repository/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package com.github.sahara3.ssolite.server.repository;

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/SsoLiteAccessTokenService.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/SsoLiteAccessTokenService.java
@@ -1,8 +1,8 @@
 package com.github.sahara3.ssolite.server.service;
 
-import javax.validation.constraints.NotNull;
-
 import com.github.sahara3.ssolite.model.SsoLiteAccessToken;
+
+import org.springframework.lang.Nullable;
 
 /**
  * Service interface of SSOLite access tokens.
@@ -20,7 +20,8 @@ public interface SsoLiteAccessTokenService {
 	 *            the access token ID.
 	 * @return the access token, or null if there is no valid token.
 	 */
-	SsoLiteAccessToken findValidAccessToken(@NotNull String tokenId);
+	@Nullable
+	SsoLiteAccessToken findValidAccessToken(String tokenId);
 
 	/**
 	 * Creates a new access token for the user.
@@ -29,7 +30,6 @@ public interface SsoLiteAccessTokenService {
 	 *            the user name.
 	 * @return the newly created access token.
 	 */
-	@NotNull
-	SsoLiteAccessToken createAccessToken(@NotNull String username);
+	SsoLiteAccessToken createAccessToken(String username);
 
 }

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/SsoLiteAccessTokenServiceImpl.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/SsoLiteAccessTokenServiceImpl.java
@@ -4,27 +4,31 @@ import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.UUID;
 
-import javax.validation.constraints.NotNull;
-
 import com.github.sahara3.ssolite.model.SsoLiteAccessToken;
 import com.github.sahara3.ssolite.server.repository.SsoLiteAccessTokenRepository;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * Implementation of {@link SsoLiteAccessTokenService} interface.
  *
  * @author sahara3
  */
-@RequiredArgsConstructor
 public class SsoLiteAccessTokenServiceImpl implements SsoLiteAccessTokenService {
 
-	@NotNull
 	private final SsoLiteAccessTokenRepository accessTokenRepository;
 
+	public SsoLiteAccessTokenServiceImpl(SsoLiteAccessTokenRepository accessTokenRepository) {
+		Assert.notNull(accessTokenRepository, "accessTokenRepository cannot be null");
+		this.accessTokenRepository = accessTokenRepository;
+	}
+
 	@Override
-	public SsoLiteAccessToken findValidAccessToken(@NonNull String tokenId) {
+	@Nullable
+	public SsoLiteAccessToken findValidAccessToken(String tokenId) {
+		Assert.notNull(tokenId, "tokenId cannot be null");
+
 		SsoLiteAccessToken token = this.accessTokenRepository.findById(tokenId);
 		if (token != null) {
 			Date now = new Date();
@@ -38,7 +42,9 @@ public class SsoLiteAccessTokenServiceImpl implements SsoLiteAccessTokenService 
 	}
 
 	@Override
-	public SsoLiteAccessToken createAccessToken(@NonNull String username) {
+	public SsoLiteAccessToken createAccessToken(String username) {
+		Assert.notNull(username, "username cannot be null");
+
 		String id = UUID.randomUUID().toString();
 		Date expired = Date.from(OffsetDateTime.now().plusSeconds(30).toInstant());
 		SsoLiteAccessToken token = new SsoLiteAccessToken(id, username, expired);

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/SsoLiteServerRedirectResolver.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/SsoLiteServerRedirectResolver.java
@@ -6,8 +6,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,11 +19,6 @@ import org.springframework.web.util.UriUtils;
 import com.github.sahara3.ssolite.model.SsoLiteAccessToken;
 import com.github.sahara3.ssolite.util.SsoLiteUriUtils;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * SSOLite redirect resolver.
  *
@@ -32,16 +27,23 @@ import lombok.extern.slf4j.Slf4j;
  * @author sahara3
  */
 @Service
-@RequiredArgsConstructor
-@Slf4j
 public class SsoLiteServerRedirectResolver {
 
-	@NotNull
+	private static final Logger LOG = LoggerFactory.getLogger(SsoLiteServerRedirectResolver.class);
+
 	protected final SsoLiteAccessTokenService tokenService;
 
-	@NotNull
-	@Setter
+	public SsoLiteServerRedirectResolver(SsoLiteAccessTokenService tokenService) {
+		Assert.notNull(tokenService, "tokenService cannot be null");
+		this.tokenService = tokenService;
+	}
+
 	protected Map<URI, URI> permittedDomainMap = new HashMap<>();
+
+	public void setPermittedDomainMap(Map<URI, URI> permittedDomainMap) {
+		Assert.notNull(permittedDomainMap, "permittedDomainMap cannot be null");
+		this.permittedDomainMap = permittedDomainMap;
+	}
 
 	/**
 	 * Resolves and returns the redirect URL after login.
@@ -55,8 +57,10 @@ public class SsoLiteServerRedirectResolver {
 	 *             thrown if the domain where the request came from is not
 	 *             permitted.
 	 */
-	public String getRedirectDestination(@NonNull String from, @NonNull Authentication authentication)
-			throws AccessDeniedException {
+	public String getRedirectDestination(String from, Authentication authentication) throws AccessDeniedException {
+		Assert.notNull(from, "from cannot be null");
+		Assert.notNull(authentication, "authentication cannot be null");
+
 		if (!UrlUtils.isAbsoluteUrl(from)) {
 			return from;
 		}
@@ -97,7 +101,9 @@ public class SsoLiteServerRedirectResolver {
 		return builder.toString();
 	}
 
-	protected URI getSsoRedirectDestinationUri(@NonNull String from) {
+	protected URI getSsoRedirectDestinationUri(String from) {
+		Assert.notNull(from, "from cannot be null");
+
 		// TODO: support a domain that have multiple applications (sso-login).
 		try {
 			URI uri = new URI(from);
@@ -109,7 +115,8 @@ public class SsoLiteServerRedirectResolver {
 		}
 	}
 
-	private static String encodeQueryParam(@NonNull String value) {
+	private static String encodeQueryParam(String value) {
+		Assert.notNull(value, "value cannot be null");
 		return UriUtils.encodeQueryParam(value, StandardCharsets.UTF_8);
 	}
 }

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/package-info.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/server/service/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package com.github.sahara3.ssolite.server.service;

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/util/SsoLiteRedirectUrlBuilder.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/util/SsoLiteRedirectUrlBuilder.java
@@ -2,21 +2,23 @@ package com.github.sahara3.ssolite.util;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
 import org.springframework.security.web.PortResolver;
 import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.util.RedirectUrlBuilder;
 import org.springframework.security.web.util.UrlUtils;
-
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.Assert;
 
 /**
  * Utility for building redirect URL builder.
  *
  * @author sahara3
  */
-@Slf4j
 public class SsoLiteRedirectUrlBuilder {
+
+	private static final Logger LOG = LoggerFactory.getLogger(SsoLiteRedirectUrlBuilder.class);
 
 	private final PortResolver portResolver = new PortResolverImpl();
 
@@ -29,7 +31,10 @@ public class SsoLiteRedirectUrlBuilder {
 	 *            the URL to redirect.
 	 * @return the redirect URL.
 	 */
-	public String buildRedirectUrl(@NonNull HttpServletRequest request, @NonNull String url) {
+	public String buildRedirectUrl(HttpServletRequest request, @NonNull String url) {
+		Assert.notNull(request, "request cannot be null");
+		Assert.notNull(url, "url cannot be null");
+
 		if (UrlUtils.isAbsoluteUrl(url)) {
 			LOG.debug("URL is absolute: {}", url);
 			return url;

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/util/SsoLiteUriUtils.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/util/SsoLiteUriUtils.java
@@ -3,7 +3,7 @@ package com.github.sahara3.ssolite.util;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import lombok.NonNull;
+import org.springframework.util.Assert;
 
 /**
  * URI utilities for SSOLIte.
@@ -19,7 +19,9 @@ public class SsoLiteUriUtils {
 	 *            the original URI.
 	 * @return the domain URI.
 	 */
-	public static URI getDomainUri(@NonNull URI uri) {
+	public static URI getDomainUri(URI uri) {
+		Assert.notNull(uri, "uri cannot be null.");
+
 		try {
 			return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), null, null, null);
 		}

--- a/ssolite/src/main/java/com/github/sahara3/ssolite/util/package-info.java
+++ b/ssolite/src/main/java/com/github/sahara3/ssolite/util/package-info.java
@@ -1,0 +1,3 @@
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package com.github.sahara3.ssolite.util;


### PR DESCRIPTION
This closes #1.

Sample projects still use lombok to avoid boilerplate code.