### PR TITLE
Add Jackson2 module to handle SsoLiteAccessTokenAuthenticationToken.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -371,6 +371,9 @@ configure(project(':ssolite-spring')) {
         api 'org.springframework.security:spring-security-core'
         api 'org.springframework.security:spring-security-web'
         api 'org.springframework.security:spring-security-config'
+        api 'com.fasterxml.jackson.core:jackson-core'
+        api 'com.fasterxml.jackson.core:jackson-databind'
+        api 'com.fasterxml.jackson.core:jackson-annotations'
         implementation 'org.springframework:spring-core'
         implementation 'org.springframework:spring-web'
     }

--- a/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/client/SsoLiteAccessTokenAuthenticationToken.java
+++ b/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/client/SsoLiteAccessTokenAuthenticationToken.java
@@ -23,6 +23,7 @@ public class SsoLiteAccessTokenAuthenticationToken extends AbstractAuthenticatio
         return this.principal;
     }
 
+    @Nullable
     private Object credentials;
 
     @Override
@@ -49,8 +50,8 @@ public class SsoLiteAccessTokenAuthenticationToken extends AbstractAuthenticatio
      * @param credentials the user credentials.
      * @param authorities the user authorities.
      */
-    public SsoLiteAccessTokenAuthenticationToken(Object principal, Object credentials,
-            Collection<? extends GrantedAuthority> authorities) {
+    public SsoLiteAccessTokenAuthenticationToken(Object principal, @Nullable Object credentials,
+            @Nullable Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         this.principal = principal;
         this.credentials = credentials;

--- a/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteAccessTokenAuthenticationTokenDeserializer.java
+++ b/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteAccessTokenAuthenticationTokenDeserializer.java
@@ -1,0 +1,80 @@
+package com.github.sahara3.ssolite.spring.jackson2;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.github.sahara3.ssolite.spring.client.SsoLiteAccessTokenAuthenticationToken;
+
+/**
+ * Jackson2 deserializer for {@link SsoLiteAccessTokenAuthenticationToken}.
+ *
+ * @author sahara3
+ */
+public class SsoLiteAccessTokenAuthenticationTokenDeserializer
+        extends JsonDeserializer<SsoLiteAccessTokenAuthenticationToken> {
+
+    @Override
+    @SuppressWarnings("boxing")
+    public SsoLiteAccessTokenAuthenticationToken deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        SsoLiteAccessTokenAuthenticationToken token = null;
+        ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+        JsonNode jsonNode = mapper.readTree(jp);
+
+        Boolean authenticated = readJsonNode(jsonNode, "authenticated").asBoolean();
+
+        JsonNode principalNode = readJsonNode(jsonNode, "principal");
+        Object principal = null;
+        if (principalNode.isObject()) {
+            principal = mapper.readValue(principalNode.traverse(mapper), Object.class);
+        }
+        else {
+            principal = principalNode.asText();
+        }
+
+        JsonNode credentialsNode = readJsonNode(jsonNode, "credentials");
+        Object credentials;
+        if (credentialsNode.isNull() || credentialsNode.isMissingNode()) {
+            credentials = null;
+        }
+        else {
+            credentials = credentialsNode.asText();
+        }
+
+        if (authenticated) {
+            List<GrantedAuthority> authorities =
+                    mapper.readValue(readJsonNode(jsonNode, "authorities").traverse(mapper),
+                            mapper.getTypeFactory().constructParametricType(List.class, GrantedAuthority.class));
+            token = new SsoLiteAccessTokenAuthenticationToken(principal, credentials, authorities);
+        }
+        else {
+            if (credentials == null) {
+                throw new JsonMappingException(jp, "credentials must not be null when not authenticated.");
+            }
+            token = new SsoLiteAccessTokenAuthenticationToken((String) credentials);
+        }
+
+        JsonNode detailsNode = readJsonNode(jsonNode, "details");
+        if (detailsNode.isNull() || detailsNode.isMissingNode()) {
+            token.setDetails(null);
+        }
+        else {
+            token.setDetails(detailsNode);
+        }
+        return token;
+    }
+
+    private static JsonNode readJsonNode(JsonNode jsonNode, String field) {
+        return jsonNode.has(field) ? jsonNode.get(field) : MissingNode.getInstance();
+    }
+}

--- a/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteAccessTokenAuthenticationTokenMixin.java
+++ b/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteAccessTokenAuthenticationTokenMixin.java
@@ -1,0 +1,21 @@
+package com.github.sahara3.ssolite.spring.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.github.sahara3.ssolite.spring.client.SsoLiteAccessTokenAuthenticationToken;
+
+/**
+ * Jackson2 mix-in for {@link SsoLiteAccessTokenAuthenticationToken}.
+ *
+ * @author sahara3
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonAutoDetect( //
+        fieldVisibility = JsonAutoDetect.Visibility.ANY, //
+        getterVisibility = JsonAutoDetect.Visibility.NONE, //
+        isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonDeserialize(using = SsoLiteAccessTokenAuthenticationTokenDeserializer.class)
+class SsoLiteAccessTokenAuthenticationTokenMixin {
+    // no member.
+}

--- a/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteJackson2Module.java
+++ b/ssolite-spring/src/main/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteJackson2Module.java
@@ -1,0 +1,33 @@
+package com.github.sahara3.ssolite.spring.jackson2;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.github.sahara3.ssolite.spring.client.SsoLiteAccessTokenAuthenticationToken;
+
+/**
+ * Jackson2 module for SSOLite.
+ *
+ * @author sahara3
+ */
+public class SsoLiteJackson2Module extends SimpleModule {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Module version.
+     */
+    public static final Version VERSION = new Version(1, 0, 0, null, null, null);
+
+    /**
+     * Constructor.
+     */
+    public SsoLiteJackson2Module() {
+        super(SsoLiteJackson2Module.class.getName(), VERSION);
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.setMixInAnnotations(SsoLiteAccessTokenAuthenticationToken.class,
+                SsoLiteAccessTokenAuthenticationTokenMixin.class);
+    }
+}

--- a/ssolite-spring/src/test/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteJackson2ModuleTest.java
+++ b/ssolite-spring/src/test/java/com/github/sahara3/ssolite/spring/jackson2/SsoLiteJackson2ModuleTest.java
@@ -1,0 +1,63 @@
+package com.github.sahara3.ssolite.spring.jackson2;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.jackson2.CoreJackson2Module;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.sahara3.ssolite.spring.client.SsoLiteAccessTokenAuthenticationToken;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SsoLiteJackson2ModuleTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void init() {
+        this.mapper = new ObjectMapper();
+        this.mapper.registerModule(new CoreJackson2Module());
+        this.mapper.registerModule(new SsoLiteJackson2Module());
+    }
+
+    static Stream<SsoLiteAccessTokenAuthenticationToken> tokenProvider() {
+        SsoLiteAccessTokenAuthenticationToken t1, t2;
+        t1 = new SsoLiteAccessTokenAuthenticationToken("testTokenId");
+
+        User user = new User("user", "password", Arrays.asList(new SimpleGrantedAuthority("ROLE_TEST")));
+        t2 = new SsoLiteAccessTokenAuthenticationToken(user, user.getPassword(), user.getAuthorities());
+
+        return Stream.of(t1, t2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("tokenProvider")
+    void testSerializeAndDeserialize(SsoLiteAccessTokenAuthenticationToken token) throws IOException {
+        String json = this.mapper.writeValueAsString(token);
+        SsoLiteAccessTokenAuthenticationToken actual =
+                this.mapper.readValue(json, SsoLiteAccessTokenAuthenticationToken.class);
+        assertThat(token, is(equalTo(actual)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("tokenProvider")
+    void testFailureWithoutJacksonModule(SsoLiteAccessTokenAuthenticationToken token) throws IOException {
+        ObjectMapper m = new ObjectMapper();
+        m.registerModule(new CoreJackson2Module());
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            String json = m.writeValueAsString(token);
+            m.readValue(json, SsoLiteAccessTokenAuthenticationToken.class);
+        });
+    }
+}


### PR DESCRIPTION
This closes #9.

If you use ObjectMapper in whitelist mode, you can use this Jackson2 module.